### PR TITLE
Add keccak256 tests and fix checksum usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "bun build src/index.ts --outfile dist/index.js",
-    "compile": "bun build src/index.ts --compile --outfile kms2eth"
+    "compile": "bun build src/index.ts --compile --outfile kms2eth",
+    "test": "bun test"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.797.0",

--- a/src/checksum.ts
+++ b/src/checksum.ts
@@ -1,0 +1,67 @@
+export function keccak256(input: string | Uint8Array): Uint8Array {
+  const RC = [
+    0x0000000000000001n,0x0000000000008082n,0x800000000000808an,0x8000000080008000n,
+    0x000000000000808bn,0x0000000080000001n,0x8000000080008081n,0x8000000000008009n,
+    0x000000000000008an,0x0000000000000088n,0x0000000080008009n,0x000000008000000an,
+    0x000000008000808bn,0x800000000000008bn,0x8000000000008089n,0x8000000000008003n,
+    0x8000000000008002n,0x8000000000000080n,0x000000000000800an,0x800000008000000an,
+    0x8000000080008081n,0x8000000000008080n,0x0000000080000001n,0x8000000080008008n
+  ];
+  const R = [
+    [0,36,3,41,18],
+    [1,44,10,45,2],
+    [62,6,43,15,61],
+    [28,55,25,21,56],
+    [27,20,39,8,14]
+  ];
+  const s = new Array<bigint>(25).fill(0n);
+  const b = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  const BLOCK = 136;
+  for (let i = 0; i < b.length; i++) {
+    s[i >> 3] ^= BigInt(b[i]) << BigInt((i % 8) * 8);
+  }
+  s[b.length >> 3] ^= 0x01n << BigInt((b.length % 8) * 8);
+  s[(BLOCK - 1) >> 3] ^= 0x80n << BigInt(((BLOCK - 1) % 8) * 8);
+  const rot = (x: bigint, n: number) =>
+    ((x << BigInt(n)) | (x >> BigInt(64 - n))) & 0xffffffffffffffffn;
+  for (let r = 0; r < 24; r++) {
+    const C = new Array<bigint>(5).fill(0n);
+    for (let x = 0; x < 5; x++) {
+      C[x] = s[x] ^ s[x + 5] ^ s[x + 10] ^ s[x + 15] ^ s[x + 20];
+    }
+    const D = new Array<bigint>(5);
+    for (let x = 0; x < 5; x++) {
+      D[x] = C[(x + 4) % 5] ^ rot(C[(x + 1) % 5], 1);
+    }
+    for (let x = 0; x < 5; x++) {
+      for (let y = 0; y < 5; y++) {
+        s[x + 5 * y] ^= D[x];
+      }
+    }
+    const B = new Array<bigint>(25);
+    for (let x = 0; x < 5; x++) {
+      for (let y = 0; y < 5; y++) {
+        B[y + 5 * ((2 * x + 3 * y) % 5)] = rot(s[x + 5 * y], R[x][y]);
+      }
+    }
+    for (let x = 0; x < 5; x++) {
+      for (let y = 0; y < 5; y++) {
+        s[x + 5 * y] =
+          B[x + 5 * y] ^ (~B[((x + 1) % 5) + 5 * y] & B[((x + 2) % 5) + 5 * y]);
+      }
+    }
+    s[0] ^= RC[r];
+  }
+  const out = Buffer.alloc(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = Number((s[i >> 3] >> BigInt((i % 8) * 8)) & 0xffn);
+  }
+  return out;
+}
+
+export function toChecksum(hex: string): string {
+  const h = Buffer.from(keccak256(hex)).toString("hex");
+  return [...hex]
+    .map((c, i) => (parseInt(h[i], 16) > 7 ? c.toUpperCase() : c))
+    .join("");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@aws-sdk/client-kms";
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
-import { keccak_256 } from "@noble/hashes/sha3";
+import { keccak256, toChecksum } from "./checksum";
 
 /* ------------ CLI & ENV ------------ */
 const cli = new Command()
@@ -111,7 +111,7 @@ if (!addrHex) {
   // Drop the 0x04 prefix to get X and Y coordinates
   const pubXY = uncompressed.slice(1);
   // Hash the public key using Keccak-256
-  const hash = keccak_256(pubXY);
+  const hash = keccak256(pubXY);
   // Take the last 20 bytes as the Ethereum address
   addrHex = Array.from(hash.slice(-20))
     .map((b) => b.toString(16).padStart(2, "0"))
@@ -149,20 +149,6 @@ function handleKmsError(
   }
   console.error(`❌  unknown error: ${error}`);
   process.exit(5);
-}
-
-/* ------------ Checksum & output ------------ */
-/**
- * Applies EIP-55 checksum to a hex string.
- */
-function toChecksum(hex: string) {
-  const h = keccak_256(hex).reduce(
-    (s, b) => s + b.toString(16).padStart(2, "0"),
-    ""
-  );
-  return [...hex]
-    .map((c, i) => (parseInt(h[i], 16) > 7 ? c.toUpperCase() : c))
-    .join("");
 }
 
 const outHex = opt.checksum ? toChecksum(addrHex) : addrHex.toLowerCase();

--- a/test/checksum.test.ts
+++ b/test/checksum.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "bun:test";
+import { toChecksum } from "../src/checksum";
+
+describe("toChecksum", () => {
+  it("formats hex string with EIP-55 checksum", () => {
+    const input = "1234567890abcdef1234567890abcdef12345678";
+    const expected = "1234567890AbcdEF1234567890aBcdef12345678";
+    expect(toChecksum(input)).toBe(expected);
+  });
+});

--- a/test/keccak.test.ts
+++ b/test/keccak.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "bun:test";
+import { keccak256 } from "../src/checksum";
+
+describe("keccak256", () => {
+  const cases: Array<[string, string]> = [
+    ["", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"],
+    ["bun", "bf957509a93fd37575215ff3ee6ea85b1fb44579ae0d1ff072c55ba2f80724fc"],
+    ["hello", "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`hashes "${input}"`, () => {
+      expect(Buffer.from(keccak256(input)).toString("hex")).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- export `keccak256` and update `toChecksum`
- use the new `keccak256` helper when hashing the KMS public key
- add table-driven tests for the `keccak256` function

## Testing
- `bun test`